### PR TITLE
test(test_main_templates): Add tests for Main app templates

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -10,7 +10,7 @@ from main.models import Tenant
 class CustomUser(AbstractUser):
     tenant = models.ForeignKey(Tenant, on_delete=models.CASCADE, null=True, blank=True, verbose_name="Организация")
 
-    def save(self, *args, **kwargs):
+    def save(self, *args, **kwargs):  # type: ignore
         if not self.tenant:
             self.tenant = Tenant.objects.create(name=self.email)
         super().save(*args, **kwargs)
@@ -18,7 +18,8 @@ class CustomUser(AbstractUser):
 
 # Add user to the Tenant group upon creation
 @receiver(post_save, sender=CustomUser)
-def add_user_to_group(sender, instance, created, **kwargs):
+def add_user_to_group(sender, instance, created, **kwargs):  # type: ignore  # pylint: disable=[unused-argument]
+
     if instance.is_superuser:
         return
     if created:

--- a/main/views.py
+++ b/main/views.py
@@ -99,7 +99,7 @@ def scrape_items(request, skus: str) -> HttpResponse | HttpResponseRedirect:
 
             logger.info("Checking for items_data: %s", items_data)
             for item_data in items_data:
-                item, created = Item.objects.update_or_create(
+                item, created = Item.objects.update_or_create(  # pylint: disable=unused-variable
                     tenant=request.user.tenant,
                     sku=item_data["sku"],
                     defaults=item_data,
@@ -138,7 +138,7 @@ def create_scrape_interval_task(request):
             interval = scrape_interval_form.cleaned_data["interval"]
             print(f"{interval=}")
             print(f'"{request.user.tenant.id=}"')
-            schedule, created = IntervalSchedule.objects.get_or_create(
+            schedule, created = IntervalSchedule.objects.get_or_create(  # pylint: disable=unused-variable
                 every=interval,
                 period=IntervalSchedule.SECONDS,
             )

--- a/pylintrc
+++ b/pylintrc
@@ -89,7 +89,9 @@ disable=R,
         long-suffix,
         map-builtin-not-iterating,
         misplaced-comparison-constant,
+        missing-class-docstring,
         missing-function-docstring,
+        missing-module-docstring,
         metaclass-assignment,
         next-method-called,
         next-method-defined,
@@ -119,6 +121,7 @@ disable=R,
         standarderror-builtin,
         suppressed-message,
         sys-max-int,
+        too-few-public-methods,
         trailing-newlines,
         unichr-builtin,
         unicode-builtin,
@@ -323,7 +326,7 @@ ignore-comments=yes
 ignore-docstrings=yes
 
 # Ignore imports when computing similarities.
-ignore-imports=no
+ignore-imports=yes
 
 
 [SPELLING]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,13 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = mp_monitor.settings
 python_files = tests.py test_*.py *_tests.py
+log_cli_format = [%(levelname)s] %(asctime)s %(filename)s:%(lineno)-4d %(name)s - %(message)s
+log_cli_date_format = %Y-%m-%d %H:%M:%S
 log_cli = true
 addopts = --log-cli-level=DEBUG
+
+; filter out the warning: The USE_L10N setting is deprecated. Starting with Django 5.0, localized formatting of data will always be enabled
+;. For example Django will display numbers and dates using the format of the current locale.
+;    warnings.warn(USE_L10N_DEPRECATED_MSG, RemovedInDjango50Warning)
+filterwarnings =
+    ignore::django.utils.deprecation.RemovedInDjango50Warning

--- a/tests/main/test_main_templates.py
+++ b/tests/main/test_main_templates.py
@@ -1,0 +1,47 @@
+import logging
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+from django.urls import reverse
+
+from main.models import Item
+
+logger = logging.getLogger(__name__)
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+class TestMainTemplates:
+    @pytest.fixture
+    def client(self) -> Client:
+        return Client()
+
+    @pytest.fixture
+    def logged_in_user(self, client: Client) -> User:
+        user = User.objects.create_user(username="testuser", email="testuser@test.com", password="testpassword")
+        client.login(username="testuser", password="testpassword")
+        return user
+
+    @pytest.fixture
+    def item(self, logged_in_user: User) -> Item:
+        return Item.objects.create(
+            tenant=logged_in_user.tenant,
+            name="Test Item",
+            sku="12345",
+            price=100,
+        )
+
+    def test_item_list_template(self, client: Client) -> None:
+        response = client.get(reverse("item_list"))
+        logger.debug("Main page response: %s", response)
+        assert response.status_code == 200
+        assert "main/item_list.html" in [t.name for t in response.templates]
+
+    def test_item_detail_template(self, client: Client, item: Item) -> None:
+        response = client.get(reverse("item_detail", kwargs={"slug": item.sku}))
+        logger.debug("Item Detail page response: %s", response)
+        assert response.status_code == 200
+        assert "main/item_detail.html" in [t.name for t in response.templates]
+


### PR DESCRIPTION
Partially addresses https://github.com/igorsimb/mp-monitor/issues/7

- Currently, only 2 templates are used: `item_list.html` and `item_detail.html`
- Made slight adjustments for `pylintrc `and some added ignores for some unnecessary type hint warnings
- Added a better format for logs into `pytest.ini`