### PR TITLE
feature(utils): add `at_least_one_item_selected` helper function

### DIFF
--- a/main/utils.py
+++ b/main/utils.py
@@ -71,6 +71,23 @@ def scrape_item(sku: str) -> dict:
     }
 
 
+def at_least_one_item_selected(request: HttpRequest, selected_item_ids: list[str]) -> bool:
+    """
+    Checks if at least one item is selected.
+    If not, displays an error message and redirects to the item list page.
+    Args:
+        request: The HttpRequest object.
+        selected_item_ids: A list of stringified integers representing the IDs of the selected items.
+    """
+    if len(selected_item_ids) == 0:
+        messages.error(request, "Выберите хотя бы 1 товар")
+        logger.warning("No items were selected.")
+        return False
+
+    logger.info("Items with these ids where selected: %s", selected_item_ids)
+    return True
+
+
 def uncheck_all_boxes(request: HttpRequest) -> None:
     Item.objects.filter(tenant=request.user.tenant.id).update(is_parser_active=False)  # type: ignore
     logger.debug("All boxes unchecked.")

--- a/main/views.py
+++ b/main/views.py
@@ -12,7 +12,7 @@ from guardian.mixins import PermissionListMixin, PermissionRequiredMixin
 
 from .forms import ScrapeForm, ScrapeIntervalForm
 from .models import Item, Price
-from .utils import scrape_item, uncheck_all_boxes, show_successful_scrape_message
+from .utils import scrape_item, uncheck_all_boxes, show_successful_scrape_message, at_least_one_item_selected
 
 user = get_user_model()
 logger = logging.getLogger(__name__)
@@ -126,6 +126,9 @@ def create_scrape_interval_task(request):
         if scrape_interval_form.is_valid():
             logger.info("Starting the task")
             selected_item_ids = request.POST.getlist("selected_items")
+
+            if not at_least_one_item_selected(request, selected_item_ids):
+                return redirect("item_list")
 
             uncheck_all_boxes(request)
 

--- a/mp_monitor/settings.py
+++ b/mp_monitor/settings.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-
+from django.contrib.messages import constants as message_constants
 from django.utils import timezone
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -166,7 +166,7 @@ CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 
 
 # Generate log file paths based on year and month
-def log_file_path(instance, filename):
+def log_file_path(instance, filename):  # pylint: disable=unused-argument
     today = timezone.now()
     log_dir = os.path.join("logs", str(today.year), today.strftime("%B"))
     os.makedirs(log_dir, exist_ok=True)  # Create the directory if it doesn't exist
@@ -238,3 +238,8 @@ LOGGING = {
         # },
     },
 }
+
+# Django Messages settings
+# Instead of "error" we use "danger" to indicate a bootstrap class
+# Source: https://docs.djangoproject.com/en/4.2/ref/settings/#message-tags
+MESSAGE_TAGS = {message_constants.ERROR: "danger"}


### PR DESCRIPTION
Fixes #25 
- The function is placed inside the `create_scrape_interval_task` view. It checks if at least one item is selected and returns True or False (with an error message). If False, the view stops and redirects back to this page.

- Added tests for the function.
- Also, in `settings.py` changed `messages `alias from "error" to "danger" to conform to bootstrap classes