### PR TITLE
refactor(scrape_items): create helper functions

### DIFF
--- a/main/templates/main/item_detail.html
+++ b/main/templates/main/item_detail.html
@@ -14,9 +14,13 @@
         <div class="row">
             <div class="col-md-6">
                 <h1>{{ item.name }}</h1>
-                <p><strong>SKU:</strong> {{ item.sku }}</p>
-                <p><strong>Latest price:</strong> ${{ item.price }}</p>
-                <p><strong>Company:</strong> {{ user.tenant }}</p>
+                <div><strong>SKU:</strong>
+                    <a href="https://www.wildberries.ru/catalog/{{ item.sku }}/detail.aspx" target="_blank">
+                        {{ item.sku }}
+                    </a>
+                </div>
+                <div><strong>Latest price:</strong> ${{ item.price }}</div>
+                <div><strong>Company:</strong> {{ user.tenant }}</div>
 
                 {% if user.groups.all%}
                     <p><strong>Groups:</strong> {% for group in user.groups.all %}{{ group }}, {% endfor %}</p>

--- a/main/urls.py
+++ b/main/urls.py
@@ -1,6 +1,12 @@
 from django.urls import path
 
-from .views import ItemListView, ItemDetailView, scrape_items, create_scrape_interval_task, destroy_scrape_interval_task
+from .views import (
+    ItemListView,
+    ItemDetailView,
+    create_scrape_interval_task,
+    destroy_scrape_interval_task,
+    scrape_items,
+)
 
 urlpatterns = [
     path("", ItemListView.as_view(), name="item_list"),


### PR DESCRIPTION
Fixes https://github.com/igorsimb/mp-monitor/issues/31 
`scrape_items` view was doing too much as one function. Now it looks cleaner and more readable.
 Created 2 additional helper functions that scrape items from skus sent by the form and update the database with the new info.
Also, added a link to the actual item on WB in the `item_detail` template