### PR TITLE
feature(utils): scrape price live with Selenium (+ spp)

### DIFF
--- a/main/models.py
+++ b/main/models.py
@@ -20,17 +20,29 @@ class Tenant(models.Model):
         verbose_name = "Организация"
         verbose_name_plural = "Организации"
 
-    def __str__(self) -> str:
+    def __str__(self):
         return self.name
 
 
 class Item(models.Model):
     tenant = models.ForeignKey(Tenant, on_delete=models.CASCADE)
     name = models.CharField(max_length=255)
-    sku = models.CharField(max_length=255)
-    price = models.DecimalField(
-        max_digits=10, decimal_places=0, null=True, validators=[MinValueValidator(float("0.00"))]
+    sku = models.CharField(max_length=20)
+    seller_price = models.DecimalField(
+        max_digits=10,
+        decimal_places=0,
+        null=True,
+        help_text="Цена товара от продавца",
+        validators=[MinValueValidator(float("0.00"))],
     )
+    price = models.DecimalField(
+        max_digits=10,
+        decimal_places=0,
+        null=True,
+        help_text="Цена товара в магазине с учетом СПП",
+        validators=[MinValueValidator(float("0.00"))],
+    )
+    spp = models.IntegerField(null=True, blank=True)
     image = models.URLField(null=True, blank=True)
     category = models.CharField(max_length=255, null=True, blank=True)
     brand = models.CharField(max_length=255, null=True, blank=True)

--- a/main/templates/main/item_list.html
+++ b/main/templates/main/item_list.html
@@ -62,7 +62,9 @@
                     <th>Enabled</th>
                     <th>SKU</th>
                     <th>Name</th>
-                    <th>Price</th>
+                    <th>Seller Price</th>
+                    <th>SPP</th>
+                    <th>WB Price</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -95,6 +97,8 @@
                         </td>
                         <td><a href="{{ item.get_absolute_url }}">{{ item.sku }}</a></td>
                         <td>({{ item.tenant.name }}) {{ item.name }} ({{ item.prices.count }})</td>
+                        <td>{{ item.seller_price }}</td>
+                        <td>{{ item.spp }}%</td>
                         <td>{{ item.price }}</td>
                     </tr>
                 {% empty %}

--- a/tests/main/test_main_views.py
+++ b/tests/main/test_main_views.py
@@ -195,6 +195,10 @@ class TestScrapeItemsView:
                                 "seller_name": data["seller_name"],
                                 "rating": data["rating"],
                                 "feedbacks": data["feedbacks"],
+                                "extended": {
+                                    "basicPriceU": data["salePriceU"],
+                                    "basicSale": 30,
+                                },
                             }
                         ]
                     },
@@ -224,13 +228,15 @@ class TestScrapeItemsView:
 
         return request
 
-    def test_post_valid_form_redirects(self, post_request_with_user: WSGIRequest) -> None:
+    def test_post_valid_form_redirects(self, post_request_with_user: WSGIRequest, mocker) -> None:
         request = post_request_with_user
+        mocker.patch("main.utils.scrape_live_price", return_value=100)
         response = scrape_items(request, f"{self.sku1}, {self.sku2}")
         assert response.status_code == 302, f"Expected status code 302, but got {response.status_code}."
 
-    def test_post_valid_form_updates_items(self, post_request_with_user: WSGIRequest) -> None:
+    def test_post_valid_form_updates_items(self, post_request_with_user: WSGIRequest, mocker) -> None:
         request = post_request_with_user
+        mocker.patch("main.utils.scrape_live_price", return_value=100)
 
         logger.info("Updating items")
         scrape_items(request, f"{self.sku1}, {self.sku2}")


### PR DESCRIPTION
- A new utility function that uses Selenium to scrape live price from WB.
- Using this information, we now calculate `spp` and add it to Item model.
- Changed the way seller's price is obtained (WB was converting PriceU into extended.BasicPriceU in the background, now we do it explicitly in `extract_valid_price` function).
- Changed test to add mocking of the new `scrape_live_price` function to avoid going live to WB