### PR TITLE
feature(items_list): replace interval with Update items feature

### DIFF
--- a/main/forms.py
+++ b/main/forms.py
@@ -14,6 +14,10 @@ class ScrapeForm(forms.Form):
     )
 
 
+class UpdateItemsForm(forms.Form):
+    pass
+
+
 class TaskForm(forms.Form):
     interval = forms.FloatField(min_value=1, label="Interval (seconds)")
 

--- a/main/templates/main/base.html
+++ b/main/templates/main/base.html
@@ -63,6 +63,7 @@
 <script src="{% static 'js/bootstrap.min.js' %}"></script>
 <script src="{% static 'js/bootstrap.bundle.min.js' %}"></script>
 <script src="{% static 'js/bootstrap.esm.min.js' %}"></script>
+<script src="{% static 'js/custom.js' %}"></script>
 
 
 </body>

--- a/main/templates/main/item_list.html
+++ b/main/templates/main/item_list.html
@@ -28,7 +28,7 @@
                         <form method="POST" action="{% url 'scrape_item' skus=form.skus.value %}">
                             {% csrf_token %}
 
-                            <label for="skus" class="form-label h4">Добавить товары для парсинга</label>
+                            <label for="skus" class="form-label h4">Добавить новые товары для парсинга</label>
                             {% render_field form.skus class="form-control" id="skus" rows="3" placeholder=form.skus.help_text %}
                             <button type="submit" class="btn btn-primary mt-2">Добавить</button>
                         </form>
@@ -36,114 +36,7 @@
                 </div>
             </div>
         </div>
-        <div class="container">
-            <form method="POST" action="{% url 'create_scrape_interval' %}">
-                {% csrf_token %}
-                <div class="container my-4">
-                    <div class="row">
-                        <div class="col-md-6">
-                            <h4>Создать Интервал</h4>
-                            <div class="container border">
-                                {# <form method="POST" class="row g-2 my-2" action="{% url 'create_scrape_interval' %}">#}
-                                <div class="row g-2 my-2">
-                                    <div class="col-auto">
-                                        <label for="intervalInput" class="visually-hidden">Интервал (секунды)</label>
-                                        {% render_field scrape_interval_form.interval type="number" class="form-control" id="intervalInput" placeholder="Секунды" %}
-                                    </div>
-                                    <div class="col-auto">
-                                        <button type="submit" class="btn btn-success">Создать</button>
-                                        <a href="{% url 'destroy_scrape_interval' %}" class="btn btn-danger">Удалить</a>
-                                    </div>
-                                    {# </form>#}
-                                </div>
-                            </div>
-
-                            <div class="mt-2">
-                                {% if scrape_interval_task %}
-                                    Активный интервал: {{ scrape_interval_task }}
-                                {% else %}
-                                    Нет активных интервалов
-                                {% endif %}
-                            </div>
-
-                        </div>
-                    </div>
-                </div>
-
-                <div class="container flex-grow-1 d-flex flex-column">
-                    <table class="table table-striped table-hover table-bordered">
-                        <thead>
-                        <tr class="text-center">
-                            <th>Активный интервал</th>
-                            <th>SKU</th>
-                            <th>Наименование</th>
-                            <th>СПП</th>
-                            <th>Цена WB</th>
-                            <th>Разница %</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        {% for item in items %}
-                            <tr>
-                                <td>
-                                    <div class="d-flex justify-content-center">
-                                        {% if item.is_parser_active %}
-                                            <div class="form-check">
-                                                <input
-                                                        class="form-check-input mt-0"
-                                                        type="checkbox"
-                                                        checked="checked"
-                                                        value="{{ item.id }}"
-                                                        name="selected_items"
-                                                >
-                                            </div>
-
-                                        {% else %}
-                                            <div class="form-check text-center">
-                                                <input
-                                                        class="form-check-input mt-0"
-                                                        type="checkbox"
-                                                        value="{{ item.id }}"
-                                                        name="selected_items"
-                                                >
-                                            </div>
-                                        {% endif %}
-                                    </div>
-                                </td>
-                                <td><a href="{{ item.get_absolute_url }}">{{ item.sku }}</a></td>
-                                <td>{{ item.name }} ({{ item.prices.count }})</td>
-                                <td class="text-center">{{ item.spp }}%</td>
-                                <td class="text-center">
-                                    <span class="position-relative">
-                                        {{ item.price }}
-                                        {% if not item.is_in_stock %}
-                                            <a title="Возможно, товара нет в наличии"
-                                               class="text-decoration-none position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger mx-1"
-                                               style="font-size: 0.5rem; cursor: help;">
-                                            !
-                                            </a>
-                                        {% endif %}
-                                    </span>
-                                </td>
-                                <td class="text-center">
-                                    {% if item.price_percent_change > 0 %}
-                                        +{{ item.price_percent_change|floatformat }}%
-                                    {% elif item.price_percent_change == 0 %}
-                                        =
-                                    {% else %}
-                                        {{ item.price_percent_change|floatformat }}%
-                                    {% endif %}
-                                </td>
-                            </tr>
-                        {% empty %}
-                            <tr>
-                                <td colspan="6">Товары не найдены</td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-            </form>
+        {% include "main/partials/update_items_form.html" %}
     </main>
 
 

--- a/main/templates/main/partials/create_interval_form.html
+++ b/main/templates/main/partials/create_interval_form.html
@@ -1,0 +1,109 @@
+{% load widget_tweaks %}
+
+<form method="POST" action="{% url 'create_scrape_interval' %}">
+    {% csrf_token %}
+    <div class="container my-4">
+        <div class="row">
+            <div class="col-md-6">
+                <h4>Создать Интервал</h4>
+                <div class="container border">
+                    {# <form method="POST" class="row g-2 my-2" action="{% url 'create_scrape_interval' %}">#}
+                    <div class="row g-2 my-2">
+                        <div class="col-auto">
+                            <label for="intervalInput" class="visually-hidden">Интервал (секунды)</label>
+                            {% render_field scrape_interval_form.interval type="number" class="form-control" id="intervalInput" placeholder="Секунды" %}
+                        </div>
+                        <div class="col-auto">
+                            <button type="submit" class="btn btn-success">Создать</button>
+                            <a href="{% url 'destroy_scrape_interval' %}" class="btn btn-danger">Удалить</a>
+                        </div>
+                        {# </form>#}
+                    </div>
+                </div>
+
+                <div class="mt-2">
+                    {% if scrape_interval_task %}
+                        Активный интервал: {{ scrape_interval_task }}
+                    {% else %}
+                        Нет активных интервалов
+                    {% endif %}
+                </div>
+
+            </div>
+        </div>
+    </div>
+
+    <div class="container flex-grow-1 d-flex flex-column">
+        <table class="table table-striped table-hover table-bordered">
+            <thead>
+            <tr class="text-center">
+                <th>Активный интервал</th>
+                <th>SKU</th>
+                <th>Наименование</th>
+                <th>СПП</th>
+                <th>Цена WB</th>
+                <th>Разница %</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for item in items %}
+                <tr>
+                    <td>
+                        <div class="d-flex justify-content-center">
+                            {% if item.is_parser_active %}
+                                <div class="form-check">
+                                    <input
+                                            class="form-check-input mt-0"
+                                            type="checkbox"
+                                            checked="checked"
+                                            value="{{ item.id }}"
+                                            name="selected_items"
+                                    >
+                                </div>
+
+                            {% else %}
+                                <div class="form-check text-center">
+                                    <input
+                                            class="form-check-input mt-0"
+                                            type="checkbox"
+                                            value="{{ item.id }}"
+                                            name="selected_items"
+                                    >
+                                </div>
+                            {% endif %}
+                        </div>
+                    </td>
+                    <td><a href="{{ item.get_absolute_url }}">{{ item.sku }}</a></td>
+                    <td>{{ item.name }} ({{ item.prices.count }})</td>
+                    <td class="text-center">{{ item.spp }}%</td>
+                    <td class="text-center">
+                                    <span class="position-relative">
+                                        {{ item.price }}
+                                        {% if not item.is_in_stock %}
+                                            <a title="Возможно, товара нет в наличии"
+                                               class="text-decoration-none position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger mx-1"
+                                               style="font-size: 0.5rem; cursor: help;">
+                                            !
+                                            </a>
+                                        {% endif %}
+                                    </span>
+                    </td>
+                    <td class="text-center">
+                        {% if item.price_percent_change > 0 %}
+                            +{{ item.price_percent_change|floatformat }}%
+                        {% elif item.price_percent_change == 0 %}
+                            =
+                        {% else %}
+                            {{ item.price_percent_change|floatformat }}%
+                        {% endif %}
+                    </td>
+                </tr>
+            {% empty %}
+                <tr>
+                    <td colspan="6">Товары не найдены</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</form>

--- a/main/templates/main/partials/update_items_form.html
+++ b/main/templates/main/partials/update_items_form.html
@@ -1,0 +1,80 @@
+{% load widget_tweaks %}
+
+<form method="POST" action="{% url 'update_items' %}">
+    {% csrf_token %}
+    <div class="container my-4">
+        <div class="row">
+            <div class="col-md-6">
+                <h4>Обновить информацию о товарах</h4>
+                <div class="container border">
+                    <div class="p-2">
+                        Выберите товары и нажмите на
+                        <button type="submit" class="btn btn-success">Обновить</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="container flex-grow-1 d-flex flex-column">
+        <table class="table table-striped table-hover table-bordered">
+            <thead>
+            <tr class="text-center">
+                <th id="select-all" style="cursor: default">Выбрать все</th>
+                <th>SKU</th>
+                <th>Наименование</th>
+                <th>СПП</th>
+                <th>Цена WB</th>
+                <th>Разница %</th>
+            </tr>
+            </thead>
+            <tbody id="table-body">
+            {% for item in items %}
+                <tr>
+                    <td>
+                        <div class="d-flex justify-content-center">
+                                <div class="form-check text-center">
+                                    <input
+                                            class="form-check-input mt-0"
+                                            type="checkbox"
+                                            value="{{ item.sku }}"
+                                            name="selected_items"
+                                    >
+                                        {% render_field update_items_form.selected_items class="form-control" id="selected_items" %}
+                                </div>
+                        </div>
+                    </td>
+                    <td><a href="{{ item.get_absolute_url }}">{{ item.sku }}</a></td>
+                    <td>{{ item.name }} ({{ item.prices.count }})</td>
+                    <td class="text-center">{{ item.spp }}%</td>
+                    <td class="text-center">
+                                    <span class="position-relative">
+                                        {{ item.price }}
+                                        {% if not item.is_in_stock %}
+                                            <a title="Возможно, товара нет в наличии"
+                                               class="text-decoration-none position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger mx-1"
+                                               style="font-size: 0.5rem; cursor: help;">
+                                            !
+                                            </a>
+                                        {% endif %}
+                                    </span>
+                    </td>
+                    <td class="text-center">
+                        {% if item.price_percent_change > 0 %}
+                            +{{ item.price_percent_change|floatformat }}%
+                        {% elif item.price_percent_change == 0 %}
+                            =
+                        {% else %}
+                            {{ item.price_percent_change|floatformat }}%
+                        {% endif %}
+                    </td>
+                </tr>
+            {% empty %}
+                <tr>
+                    <td colspan="6">Товары не найдены</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</form>

--- a/main/urls.py
+++ b/main/urls.py
@@ -6,6 +6,8 @@ from .views import (
     create_scrape_interval_task,
     destroy_scrape_interval_task,
     scrape_items,
+    update_items,
+
 )
 
 urlpatterns = [
@@ -13,6 +15,7 @@ urlpatterns = [
     path("scrape_interval/", create_scrape_interval_task, name="create_scrape_interval"),
     path("destroy_scrape_interval/", destroy_scrape_interval_task, name="destroy_scrape_interval"),
     # path("<str:username>/<str:slug>/", ItemDetailView.as_view(), name="item_detail"),
-    path("<str:slug>/", ItemDetailView.as_view(), name="item_detail"),
+    path("items/<str:slug>/", ItemDetailView.as_view(), name="item_detail"),
     path("scrape/<str:skus>/", scrape_items, name="scrape_item"),
+    path("update_items/", update_items, name="update_items"),
 ]

--- a/main/utils.py
+++ b/main/utils.py
@@ -262,7 +262,7 @@ def update_or_create_items(request, items_data):
         )
 
 
-def is_at_least_one_item_selected(request: HttpRequest, selected_item_ids: list[str]) -> bool:
+def is_at_least_one_item_selected(request: HttpRequest, selected_item_ids: list[str] | str) -> bool:
     """Checks if at least one item is selected.
 
     If not, displays an error message and redirects to the item list page.

--- a/static/js/custom.js
+++ b/static/js/custom.js
@@ -1,0 +1,19 @@
+function toggleAllCheckboxes() {
+    var checkboxes = document.getElementById('table-body').getElementsByTagName('input');
+    var allChecked = true;
+    for (var i = 0; i < checkboxes.length; i++) {
+        if (checkboxes[i].type === 'checkbox' && !checkboxes[i].checked) {
+            allChecked = false;
+            break;
+        }
+    }
+    for (var i = 0; i < checkboxes.length; i++) {
+        if (checkboxes[i].type === 'checkbox') {
+            checkboxes[i].checked = !allChecked;
+        }
+    }
+}
+
+window.onload = function() {
+    document.getElementById('select-all').addEventListener('click', toggleAllCheckboxes);
+};


### PR DESCRIPTION
For current needs, we only need to be able to update items that are selected in the table. Creating interval will come in future updates.

Created "partials" folder to store the form.

Created an empty `UpdateItemsForm` to avoid confusion with `ScrapeForm` and a new `update_items` view.

Created a `toggleAllCheckboxes` JS script to toggle all checkboxes in the table.

Added a test for `update_items` view