### PR TITLE
refactor(factories): change email and username generation in UserFactory

### DIFF
--- a/main/models.py
+++ b/main/models.py
@@ -17,9 +17,12 @@ logger = logging.getLogger(__name__)
 
 class TenantManager(models.Manager):
     def active(self) -> models.QuerySet:
-        # in ORM: Tenant.objects.active()
+        """
+        Returns only active tenants.
+        Can be used in ORM like so: Tenant.objects.active()
+        """
         qs = self.get_queryset()
-        return qs.filter(status__in=self.model.ACTIVE_STATUSES)
+        return qs.filter(status__in=self.model.ACTIVE_STATUSES)  # type: ignore
 
 
 class Tenant(models.Model):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -16,6 +16,7 @@ class UserFactory(DjangoModelFactory):
     class Meta:
         model = settings.AUTH_USER_MODEL
 
-    username = factory.Faker("user_name")
-    email = factory.Faker("email")
+    # Sequence preferred over factory.Faker("email") to better match username using similar sequence
+    email = factory.Sequence(lambda n: f"user_{n}@testing.com")
+    username = factory.Sequence(lambda n: f"user_{n}")
     password = factory.PostGenerationMethodCall("set_password", "password")

--- a/tests/main/test_main_models.py
+++ b/tests/main/test_main_models.py
@@ -34,8 +34,8 @@ class TestTenantModel:
         TenantFactory(status=Tenant.Status.CANCELED)
         TenantFactory(status=Tenant.Status.TRIAL_EXPIRED)
 
-        active_tenants = set(Tenant.objects.active())
-        assert active_tenants == {trialing, active, exempt}
+        active_tenants = Tenant.objects.active()  # Queryset, aka a set
+        assert set(active_tenants) == {trialing, active, exempt}
 
     def test_tenant_name_is_equal_to_user_email(self) -> None:
         user = UserFactory()


### PR DESCRIPTION
Sequence is preferred over factory.Faker("email") to better match username using similar sequence (e.g. username=`user_0`, email=`user_0@testing.com`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added detailed documentation for the `active` method in the `TenantManager` class.
- **Refactor**
	- Updated user email and username generation in `UserFactory` for consistency and control.
- **Tests**
	- Improved the reliability of tenant comparison in `test_active_tenant` by explicitly converting querysets to sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->