### PR TITLE
fix(views): remove `scrape_interval_task` from `request.session`

### DIFF
--- a/main/forms.py
+++ b/main/forms.py
@@ -4,6 +4,7 @@ from django.forms import ModelForm
 from main.models import Schedule
 
 
+# Currently not used because sku format validation is done by is_sku_format_valid utility function
 def validate_sku_format(value: str) -> None:
     if not value.isdigit() or len(value) < 5:
         raise forms.ValidationError("Неверный формат SKU.")

--- a/main/templates/main/partials/create_interval_form.html
+++ b/main/templates/main/partials/create_interval_form.html
@@ -7,7 +7,8 @@
     <div class="row g-3 mb-3">
         <div class="col-auto pt-1">Обновлять информацию с Wildberries каждые</div>
         <div class="col-auto">
-            {% render_field scrape_interval_form.interval_value min="1" class="form-control" style="max-width: 5rem" %}
+            {# Since maxlength does not work with "number" type, using JS to truncate anything beyond maxlength #}
+            {% render_field scrape_interval_form.interval_value min="1" maxlength="6" class="form-control" style="max-width: 6rem" oninput="limitMaxLength(this)" %}
         </div>
         <div class="col-auto">
             {% render_field scrape_interval_form.period class="form-select" %}

--- a/main/utils.py
+++ b/main/utils.py
@@ -545,7 +545,7 @@ def add_price_trend_indicator(prices: Page) -> None:
 
 
 def task_name(user: User) -> str:
-    return f"task_{user.tenant}"
+    return f"task_tenant_{user.tenant.id}"
 
 
 def periodic_task_exists(request: WSGIRequest) -> bool:

--- a/static/js/custom.js
+++ b/static/js/custom.js
@@ -48,3 +48,10 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 });
+
+function limitMaxLength(input) {
+    if (input.value.length > input.maxLength) {
+        input.value = input.value.slice(0, input.maxLength);
+    }
+}
+

--- a/tests/main/test_main_views.py
+++ b/tests/main/test_main_views.py
@@ -43,7 +43,6 @@ class TestItemListView:
         "sku",
         "form",
         "scrape_interval_form",
-        "scrape_interval_task",
     ]
 
     @pytest.fixture
@@ -63,7 +62,7 @@ class TestItemListView:
 
     # https://docs.djangoproject.com/en/4.2/topics/testing/advanced/#testing-class-based-views
     @pytest.mark.parametrize("expected_context_item", context_object_list)
-    def test_item_present_in_context(self, request_with_user: WSGIRequest, expected_context_item: str) -> None:
+    def test_no_task_present_in_context(self, request_with_user: WSGIRequest, expected_context_item: str) -> None:
         request = request_with_user
 
         view = ItemListView()


### PR DESCRIPTION
Fixes #104

Also changed the name of the scrape task to include tenant id instead of tenant name.