### PR TITLE
fix(forms): remove "seconds" and "minutes" for non-staff and non-superusers

### DIFF
--- a/main/templates/main/base.html
+++ b/main/templates/main/base.html
@@ -64,7 +64,7 @@
             <li class="nav-item"><a href="{% url 'index' %}" class="nav-link" aria-current="page">Главная</a></li>
             <li class="nav-item"><a href="#how_does_it_work" class="nav-link" aria-current="page">Как это работает?</a></li>
             <li class="nav-item"><a href="#faq" class="nav-link">FAQ</a></li>
-            <li class="nav-item"><a href="{% url 'account_login' %}" class="nav-link">Логин</a></li>
+            <li class="nav-item"><a href="{% url 'account_login' %}" class="nav-link">Войти</a></li>
             <li class="nav-item"><a href="{% url 'account_signup' %}" class="nav-link link-primary fw-semibold">Регистрация</a></li>
         </ul>
     </nav>

--- a/main/views.py
+++ b/main/views.py
@@ -54,7 +54,7 @@ class ItemListView(PermissionListMixin, ListView):
 
         form = ScrapeForm()
         update_items_form = UpdateItemsForm()
-        scrape_interval_form = ScrapeIntervalForm()
+        scrape_interval_form = ScrapeIntervalForm(user=self.request.user)
 
         try:
             periodic_task = PeriodicTask.objects.get(name=task_name(self.request.user))
@@ -186,7 +186,7 @@ def create_scrape_interval_task(
     """
 
     if request.method == "POST":
-        scrape_interval_form = ScrapeIntervalForm(request.POST)
+        scrape_interval_form = ScrapeIntervalForm(request.POST or None, user=request.user)
 
         if scrape_interval_form.is_valid():
             logger.info("Starting the task")
@@ -276,7 +276,7 @@ def create_scrape_interval_task(
             request,
             "Что-то пошло не так. Попробуйте еще раз или обратитесь к администратору.",
         )
-        scrape_interval_form = ScrapeIntervalForm()
+        scrape_interval_form = ScrapeIntervalForm(user=request.user)
 
     context = {"scrape_interval_form": scrape_interval_form}
     return render(request, "main/item_list.html", context)
@@ -297,7 +297,7 @@ def update_scrape_interval(request: WSGIRequest) -> HttpResponse:
     """
     existing_task = get_object_or_404(PeriodicTask, name=task_name(request.user))
     if request.method == "POST":
-        form = ScrapeIntervalForm(request.POST or None, instance=existing_task)
+        form = ScrapeIntervalForm(request.POST or None, instance=existing_task, user=request.user)
 
         if form.is_valid():
             skus = request.POST.getlist("selected_items")
@@ -324,9 +324,9 @@ def update_scrape_interval(request: WSGIRequest) -> HttpResponse:
                 request,
                 "Что-то пошло не так. Попробуйте еще раз или обратитесь к администратору.",
             )
-            form = ScrapeIntervalForm()
+            form = ScrapeIntervalForm(user=request.user)
     else:
-        form = ScrapeIntervalForm()
+        form = ScrapeIntervalForm(user=request.user)
 
     context = {"scrape_interval_form": form}
     return render(request, "main/item_list.html", context)

--- a/tests/main/test_main_views.py
+++ b/tests/main/test_main_views.py
@@ -491,7 +491,7 @@ class TestCreateScrapeIntervalTaskView:
     def valid_form_data(self) -> dict[str, Any]:
         return {
             "interval_value": 60,
-            "period": "seconds",
+            "period": "hours",
         }
 
     @pytest.mark.skip


### PR DESCRIPTION
Fixes #120
Note that any initialization of ScrapeIntervalForm now requires user parameter, e.g.: `scrape_interval_form = ScrapeIntervalForm(user=request.user)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `ScrapeIntervalForm` to restrict time interval choices for non-staff and non-superusers.

- **Bug Fixes**
	- Changed the text for the login link from "Логин" to "Войти" in the main template for improved clarity.

- **Tests**
	- Enhanced testing for form behavior with different user roles.
	- Updated test data to reflect changes in form time interval handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->