### PR TITLE
feat(main.views): implement rate limiting for scrape_items and update_items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,7 +78,7 @@ static/css/bootstrap_slate.min.css
 static/css/bootstrap_united.min.css
 static/css/bootstrap_zephyr.min.css
 static/css/bootstrap_sketchy.min.css
-/main/scripts/
+main/scripts/
 
 docker-compose.yml
 docker-compose_backup.yml

--- a/mp_monitor/settings.py
+++ b/mp_monitor/settings.py
@@ -308,3 +308,6 @@ SILENCED_SYSTEM_CHECKS: list[str] = ["security.W009"]
 # sentry-sdk
 SENTRY_ENABLED = env("SENTRY_ENABLED")
 SENTRY_DSN = env("SENTRY_DSN")
+
+# rate limiting
+RATELIMIT_ENABLE = True  # set to False to disable all rate limiting

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,7 @@ django-environ==0.11.2
 django-extensions==3.2.3
 django-guardian==2.4.0
 django-htmx==1.17.3
+django-ratelimit==4.1.0
 django-simple-history==3.5.0
 django-stubs==4.2.7
 django-stubs-ext==4.2.7


### PR DESCRIPTION
Fixes #125
Limiting POST requests for adding new items and manual updates help reduce requests to WB's API.