### PR TITLE
feature(signals): add signals for assigning default plan and quota

### DIFF
--- a/accounts/apps.py
+++ b/accounts/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class AccountsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "accounts"
+
+    def ready(self):
+        import accounts.signals  # noqa

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -30,7 +30,7 @@ class TenantQuota(models.Model):
                 "parse_units_limit": DEFAULT_QUOTAS[PlanType.FREE]["parse_units_limit"],
             },
         )
-        return quota.id
+        return quota
 
     def __str__(self):
         return self.name if self.name else f"SKUs: {self.skus_limit}, PUs:{self.parse_units_limit}"
@@ -57,7 +57,7 @@ class PaymentPlan(models.Model):
     @classmethod
     def get_default_payment_plan(cls) -> "PaymentPlan":
         plan, created = cls.objects.get_or_create(name=cls.PlanName.FREE)
-        return plan.id
+        return plan
 
     def __str__(self):
         return f"{self.name} - {self.get_name_display()}"

--- a/accounts/signals.py
+++ b/accounts/signals.py
@@ -1,6 +1,21 @@
-# from django.db import transaction
-# from django.db.models.signals import post_save, pre_save
-# from django.dispatch import receiver
-#
-# from accounts.models import Tenant, TenantQuota
+from django.db import transaction
+from django.db.models.signals import post_save
+from django.dispatch import receiver
 
+from accounts.models import Tenant, TenantQuota, PaymentPlan
+
+
+@receiver(post_save, sender=Tenant)
+@transaction.atomic
+def assign_default_plan(sender, instance, created, **kwargs):
+    if created:
+        instance.payment_plan = PaymentPlan.get_default_payment_plan()
+        instance.save()
+
+
+@receiver(post_save, sender=Tenant)
+@transaction.atomic
+def assign_default_plan_quota(sender, instance, created, **kwargs):
+    if created:
+        instance.quota = TenantQuota.get_default_quota()
+        instance.save()

--- a/tests/accounts/test_accounts_signals.py
+++ b/tests/accounts/test_accounts_signals.py
@@ -1,0 +1,37 @@
+from accounts.models import TenantQuota, PaymentPlan
+from config import PlanType, DEFAULT_QUOTAS
+from tests.factories import TenantFactory
+
+
+def test_default_plan_is_assigned() -> None:
+    """Test that the default payment plan is assigned to a new tenant."""
+    tenant = TenantFactory()
+    free_plan = PaymentPlan.get_default_payment_plan()
+    assert tenant.payment_plan == free_plan
+
+
+def test_default_plan_is_free() -> None:
+    """Test that the default payment plan is FREE."""
+    tenant = TenantFactory()
+    assert tenant.payment_plan.name == PaymentPlan.PlanName.FREE.value
+
+
+def test_default_plan_quota_is_assigned() -> None:
+    """Test that the default quota is assigned to a new tenant."""
+    tenant = TenantFactory()
+    free_plan_quota = TenantQuota.get_default_quota()
+    assert tenant.quota == free_plan_quota
+
+
+def test_default_plan_quota_is_correct() -> None:
+    """Test that the default quota is the same as in config.py file."""
+    tenant = TenantFactory()
+    assert tenant.quota.skus_limit == DEFAULT_QUOTAS[PlanType.FREE]["skus_limit"]
+    assert tenant.quota.parse_units_limit == DEFAULT_QUOTAS[PlanType.FREE]["parse_units_limit"]
+
+
+def test_not_default_plan_quota_is_not_correct() -> None:
+    """Test that the default quota is not BUSINESS plan quota from config.py file."""
+    tenant = TenantFactory()
+    assert tenant.quota.skus_limit != DEFAULT_QUOTAS[PlanType.BUSINESS]["skus_limit"]
+    assert tenant.quota.parse_units_limit != DEFAULT_QUOTAS[PlanType.BUSINESS]["parse_units_limit"]

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -22,7 +22,7 @@ class UserFactory(DjangoModelFactory):
     email = factory.Sequence(lambda n: f"user_{n}@testing.com")
     username = factory.Sequence(lambda n: f"user_{n}")
     password = factory.PostGenerationMethodCall("set_password", "password")
-    tenant = factory.RelatedFactory(TenantFactory, "name")
+    tenant = factory.RelatedFactory(TenantFactory)
 
 
 class IntervalScheduleFactory(DjangoModelFactory):


### PR DESCRIPTION
Scenario:
User creates a new tenant
Given a new tenant
When the tenant is created
Then the default plan is assigned to the tenant
And the default quota is assigned to the tenant

Also, created tests for the signals