### PR TITLE
feature(views): set min interval for FREE plan

### DIFF
--- a/main/exceptions.py
+++ b/main/exceptions.py
@@ -1,3 +1,6 @@
+from accounts.models import Tenant
+
+
 class InvalidSKUException(Exception):
     """Exception raised for invalid SKUs."""
 
@@ -33,3 +36,38 @@ class QuotaExceededException(Exception):
 
     def __str__(self):
         return f"Quota exceeded: {self.quota_type} - Message: {self.message}"
+
+
+class PlanScheduleLimitationException(Exception):
+    """
+    Exception raised for violating plan schedule limitations.
+
+    Attributes:
+        tenant (Tenant): The tenant associated with the plan limitation.
+        plan (str): The name of the plan associated with the plan limitation.
+        period (str): The time unit (e.g., "hours", "days")
+        interval (int): The interval value (e.g., 7, 24, 48)
+        message (str): The error message.
+
+    Example:
+        if request.user.tenant.payment_plan.name == PaymentPlan.PlanName.FREE.value:
+            if period == "hours" and interval < 24:
+                raise PlanScheduleLimitationException(
+                    request.user.tenant,
+                    plan=request.user.tenant.payment_plan.name,
+                    period=period,
+                    interval=interval,
+                    message="Ограничения бесплатного тарифа. Установите интервал не менее 24 часов",
+                    )
+    """
+
+    def __init__(self, tenant: Tenant, plan: str, period: str, interval: int, message: str = None):
+        super().__init__(tenant, period, interval)
+        self.tenant = tenant
+        self.plan = plan
+        self.period = period
+        self.interval = interval
+        self.message = message
+
+    def __str__(self):
+        return self.message

--- a/main/templates/main/partials/create_interval_form.html
+++ b/main/templates/main/partials/create_interval_form.html
@@ -8,7 +8,7 @@
         <div class="col-auto pt-1">Обновлять информацию с Wildberries каждые</div>
         <div class="col-auto">
             {# Since maxlength does not work with "number" type, using JS to truncate anything beyond maxlength #}
-            {% render_field scrape_interval_form.interval_value min="1" maxlength="6" class="form-control" style="max-width: 6rem" oninput="limitMaxLength(this)" %}
+            {% render_field scrape_interval_form.interval_value min="1" maxlength="6" class="form-control" id="interval-value" style="max-width: 6rem" oninput="limitMaxLength(this)" %}
         </div>
         <div class="col-auto">
             {% render_field scrape_interval_form.period class="form-select" %}


### PR DESCRIPTION
Fixes #201
FREE plan's schedule interval now cannot be less than 24 hours.